### PR TITLE
Fix incorrect call to get_sine in get_near_end (Fixes lib_aec jenkins)

### DIFF
--- a/python/audio_generation.py
+++ b/python/audio_generation.py
@@ -122,7 +122,8 @@ def get_near_end(duration, frequencies=[700], sample_rate=DEFAULT_SAMPLE_RATE,
                  rshift=4):
     """ Gets a near-end signal (alias for get_sine)
     Duration is in seconds."""
-    return get_sine(duration, frequencies, sample_rate, rshift)
+    return get_sine(duration, frequencies, sample_rate=sample_rate,
+                    rshift=rshift)
 
 
 def get_ref_discrete(duration, freq_a=1000, freq_b=2000, period=1,


### PR DESCRIPTION
This change is necessary for the jenkins tests to pass on lib_aec.