### PR TITLE
Cleanup python setup file

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -20,5 +20,7 @@ setuptools.setup(
         'pytest~=6.0',
         'pytest-xdist~=1.34',
         'scipy~=1.4',
-    ]
+    ],
+    dependency_links=[
+    ],
 )


### PR DESCRIPTION
Add empty dependency_links argument.  The empty dependency_links list makes all setup.py files similar in content.