### PR TITLE
Fix missing flag in test Makefile

### DIFF
--- a/tests/test_xscope_process_wav/Makefile
+++ b/tests/test_xscope_process_wav/Makefile
@@ -4,7 +4,7 @@ APP_NAME =
 
 SOURCE_DIRS = src .
 
-XCC_FLAGS = -O2 -g -Wall -report
+XCC_FLAGS = -O2 -g -Wall -report -DTEST_WAV_XSCOPE=1
 
 USED_MODULES = lib_voice_toolbox audio_test_tools
 


### PR DESCRIPTION
replaces https://github.com/xmos/audio_test_tools/pull/146