### PR TITLE
Initial conversion for use on XS3 platforms

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Audio test tools change log
   * ADDED: test_wav_xscope test feature
   * ADDED: lib_xs3_math as a library upon which this one depends
   * ADDED: ATT-specific synonyms for DSP and XS3-math types
+  * CHANGED: use Voice Toolbox to count leading sign bits instead of DSP library
 
 4.2.0
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,15 +1,12 @@
 Audio test tools change log
 ===========================
 
-4.3.1
------
-
-  * FIXED: test_wav_xx build failure for non-xscope (axe) apps
-
 4.3.0
 -----
 
   * ADDED: test_wav_xscope test feature
+  * ADDED: lib_xs3_math as a library upon which this one depends
+  * ADDED: ATT-specific synonyms for DSP and XS3-math types
 
 4.2.0
 -----

--- a/audio_test_tools/api/att_types.h
+++ b/audio_test_tools/api/att_types.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2020, XMOS Ltd, All rights reserved
+#ifndef ATT_TYPES_H_
+#define ATT_TYPES_H_
+
+/**
+ * Definition of types in general use throughout the Audio Test Tools.
+ */
+
+#if defined(__XS3A__)
+    #include "xs3_math.h"
+#else
+    #include "dsp.h"
+#endif // defined(__XS3A__)
+
+/**
+ * Struct containing a complex floating point number.
+ */
+#if defined(__XS3A__)
+    typedef complex_float_t att_complex_fp;
+#else
+    typedef dsp_complex_fp att_complex_fp;
+#endif // defined(__XS3A__)
+
+/**
+ * Struct containing a complex number.
+ * Both the real and imaginary parts are represented as short fixed point
+ * values, with a Q value that depends on the use case.
+ */
+#if defined(__XS3A__)
+    typedef complex_s16_t att_complex_short_t;
+#else
+    typedef dsp_complex_short_t att_complex_short_t;
+#endif // defined(__XS3A__)
+
+/**
+ * Struct containing a complex number.
+ * Both the real and imaginary parts are represented as fixed point
+ * values, with a Q value that depends on the use case.
+ */
+#if defined(__XS3A__)
+    typedef complex_s32_t att_complex_t;
+#else
+    typedef dsp_complex_t att_complex_t;
+#endif // defined(__XS3A__)
+
+#endif // ATT_TYPES_H_

--- a/audio_test_tools/api/att_types.h
+++ b/audio_test_tools/api/att_types.h
@@ -16,7 +16,7 @@
  * Struct containing a complex floating point number.
  */
 #if defined(__XS3A__)
-    typedef complex_float_t att_complex_fp;
+    typedef complex_double_t att_complex_fp;
 #else
     typedef dsp_complex_fp att_complex_fp;
 #endif // defined(__XS3A__)

--- a/audio_test_tools/api/audio_test_tools.h
+++ b/audio_test_tools/api/audio_test_tools.h
@@ -5,9 +5,9 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+#include "att_types.h"
 #include "dsp.h"
 #include "xscope_settings.h"
-#include "att_types.h"
 
 #define CRC_POLY (0xEB31D82E)
 #define ATT_WAV_HEADER_BYTES 44

--- a/audio_test_tools/api/audio_test_tools.h
+++ b/audio_test_tools/api/audio_test_tools.h
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 #include "dsp.h"
 #include "xscope_settings.h"
+#include "att_types.h"
 
 #define CRC_POLY (0xEB31D82E)
 #define ATT_WAV_HEADER_BYTES 44
@@ -94,11 +95,11 @@ long att_wav_get_frame_start(const att_wav_header &s, unsigned frame_number, uin
  * Double precision DTF
  */
 void att_make_sine_table(double * sine_lut, unsigned proc_frame_length);
-void att_bit_reverse    ( dsp_complex_fp pts[], const uint32_t N );
-void att_forward_fft    ( dsp_complex_fp pts[], const uint32_t N, const double sine[]);
-void att_inverse_fft    ( dsp_complex_fp pts[], const uint32_t N, const double sine[]);
-void att_split_spectrum ( dsp_complex_fp pts[], const uint32_t N );
-void att_merge_spectra  ( dsp_complex_fp pts[], const uint32_t N );
+void att_bit_reverse    ( att_complex_fp pts[], const uint32_t N );
+void att_forward_fft    ( att_complex_fp pts[], const uint32_t N, const double sine[]);
+void att_inverse_fft    ( att_complex_fp pts[], const uint32_t N, const double sine[]);
+void att_split_spectrum ( att_complex_fp pts[], const uint32_t N );
+void att_merge_spectra  ( att_complex_fp pts[], const uint32_t N );
 
 //Returns the interpolated center bin and interpolated peak
 {double, double} att_poly_interpolate(double left, double peak, double right, double center_bin);
@@ -129,18 +130,18 @@ uint32_t att_double_to_uint32(double d, const int d_exp);
 int64_t att_double_to_int64(double d, const int d_exp);
 uint64_t att_double_to_uint64(double d, const int d_exp);
 
-dsp_complex_fp att_complex_int16_to_double(dsp_complex_short_t x, int x_exp);
-dsp_complex_fp att_complex_int32_to_double(dsp_complex_t x, int x_exp);
+att_complex_fp att_complex_int16_to_double(att_complex_short_t x, int x_exp);
+att_complex_fp att_complex_int32_to_double(att_complex_t x, int x_exp);
 
 q8_24 att_uint32_to_q24(uint32_t v, int v_exp);
 
 /*
  * Float/Fixed vector comparision
  */
-unsigned att_bfp_vector_complex_short(dsp_complex_short_t * B, int B_exp, dsp_complex_fp * f, size_t start, size_t count);
+unsigned att_bfp_vector_complex_short(att_complex_short_t * B, int B_exp, att_complex_fp * f, size_t start, size_t count);
 unsigned att_bfp_vector_uint16(uint16_t * B, int B_exp, double * f, size_t start, size_t count);
 unsigned att_bfp_vector_int16(int16_t * B, int B_exp, double * f, size_t start, size_t count);
-unsigned att_bfp_vector_complex(dsp_complex_t * B, int B_exp, dsp_complex_fp * f, size_t start, size_t count);
+unsigned att_bfp_vector_complex(att_complex_t * B, int B_exp, att_complex_fp * f, size_t start, size_t count);
 unsigned att_bfp_vector_uint32(uint32_t * B, int B_exp, double * f, size_t start, size_t count);
 unsigned att_bfp_vector_int32(int32_t * B, int B_exp, double * f, size_t start, size_t count);
 unsigned long long att_bfp_vector_uint64(uint64_t * B, int B_exp, double * f, size_t start, size_t count);
@@ -150,36 +151,36 @@ unsigned long long att_bfp_vector_int64(int64_t * B, int B_exp, double * f, size
  * Python pretty printers
  */
 
-void att_print_int_python_fd(dsp_complex_t * d, size_t length);
-void att_print_int_python_td(dsp_complex_t * d, size_t length, int print_imag);
+void att_print_int_python_fd(att_complex_t * d, size_t length);
+void att_print_int_python_td(att_complex_t * d, size_t length, int print_imag);
 void att_print_int_python_int32(int32_t * d, size_t length);
 void att_print_int_python_uint32(uint32_t * d, size_t length);
 void att_print_int_python_int64(int64_t * d, size_t length);
 void att_print_int_python_uint64(uint64_t * d, size_t length);
 
 
-void att_print_python_fd_shortd(dsp_complex_short_t * d, size_t length, int d_exp);
-void att_print_python_td_short(dsp_complex_short_t * d, size_t length, int d_exp, int print_imag);
-void att_print_python_fd(dsp_complex_t * d, size_t length, int d_exp);
-void att_print_python_td(dsp_complex_t * d, size_t length, int d_exp, int print_imag);
+void att_print_python_fd_shortd(att_complex_short_t * d, size_t length, int d_exp);
+void att_print_python_td_short(att_complex_short_t * d, size_t length, int d_exp, int print_imag);
+void att_print_python_fd(att_complex_t * d, size_t length, int d_exp);
+void att_print_python_td(att_complex_t * d, size_t length, int d_exp, int print_imag);
 void att_print_python_int16(int16_t * d, size_t length, int d_exp);
 void att_print_python_uint16(uint16_t * d, size_t length, int d_exp);
 void att_print_python_int32(int32_t * d, size_t length, int d_exp);
 void att_print_python_uint32(uint32_t * d, size_t length, int d_exp);
 void att_print_python_int64(int64_t * d, size_t length, int d_exp);
 void att_print_python_uint64(uint64_t * d, size_t length, int d_exp);
-void att_print_python_fd_fp(dsp_complex_fp * d, size_t length);
-void att_print_python_td_fp(dsp_complex_fp * d, size_t length, int print_imag);
+void att_print_python_fd_fp(att_complex_fp * d, size_t length);
+void att_print_python_td_fp(att_complex_fp * d, size_t length, int print_imag);
 
 /*
  * DSP tracers
  */
 #define ATT_FRAME_NUMBER_INIT (-1)
 void att_trace_new_frame(unsigned & frame_number);
-void att_trace_complex_fd_short(char name[], dsp_complex_short_t * d, int exponent, unsigned length);
-void att_trace_complex_td_short(char name[], dsp_complex_short_t * d, int exponent, unsigned length, int print_imag);
-void att_trace_complex_fd(char name[], dsp_complex_t * d, int exponent, unsigned length);
-void att_trace_complex_td(char name[], dsp_complex_t * d, int exponent, unsigned length, int print_imag);
+void att_trace_complex_fd_short(char name[], att_complex_short_t * d, int exponent, unsigned length);
+void att_trace_complex_td_short(char name[], att_complex_short_t * d, int exponent, unsigned length, int print_imag);
+void att_trace_complex_fd(char name[], att_complex_t * d, int exponent, unsigned length);
+void att_trace_complex_td(char name[], att_complex_t * d, int exponent, unsigned length, int print_imag);
 
 void att_trace_uint16(char name[], uint16_t *d, int exponent, unsigned length);
 void att_trace_int16(char name[], int16_t *d, int exponent, unsigned length);
@@ -205,6 +206,6 @@ void att_burn_thread_div();
 void att_divide_array(unsigned * array, unsigned array_length, unsigned space_to_divide, int use_all_space, unsigned &r);
 
 //Limit the number of significant bit of information in a complex array.
-void att_limit_bits(dsp_complex_t * a, unsigned length, unsigned bits);
+void att_limit_bits(att_complex_t * a, unsigned length, unsigned bits);
 
 #endif /* AUDIO_TEST_TOOLS_H_ */

--- a/audio_test_tools/module_build_info
+++ b/audio_test_tools/module_build_info
@@ -1,7 +1,8 @@
 VERSION = 4.3.0
 
 DEPENDENT_MODULES = lib_dsp(>=6.0.1) \
-                    lib_voice_toolbox(>=8.0.0)
+                    lib_voice_toolbox(>=8.0.0) \
+                    lib_xs3_math
 
 MODULE_XCC_FLAGS = $(XCC_FLAGS)
 

--- a/audio_test_tools/src/floating_fft.xc
+++ b/audio_test_tools/src/floating_fft.xc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019, XMOS Ltd, All rights reserved
+// Copyright (c) 2017-2020, XMOS Ltd, All rights reserved
 #include <math.h>
 #include <string.h>
 #include <stdio.h>

--- a/audio_test_tools/src/floating_fft.xc
+++ b/audio_test_tools/src/floating_fft.xc
@@ -21,7 +21,7 @@ void att_make_sine_table(double * sine_lut, unsigned proc_frame_length){
 }
 
 #pragma unsafe arrays
-void att_bit_reverse( dsp_complex_fp pts[], const uint32_t N )
+void att_bit_reverse( att_complex_fp pts[], const uint32_t N )
 {
     uint32_t shift = clz(N);
     for(uint32_t i = 1; i < N-1; i++) {
@@ -42,7 +42,7 @@ void att_bit_reverse( dsp_complex_fp pts[], const uint32_t N )
 
 #pragma unsafe arrays
 void att_forward_fft (
-    dsp_complex_fp pts[],
+    att_complex_fp pts[],
     const uint32_t  N,
     const double   sine[] )
 {
@@ -92,7 +92,7 @@ void att_forward_fft (
 
 #pragma unsafe arrays
 void att_inverse_fft (
-    dsp_complex_fp pts[],
+    att_complex_fp pts[],
     const uint32_t  N,
     const double   sine[] )
 {
@@ -147,7 +147,7 @@ void att_inverse_fft (
 }
 
 #pragma unsafe arrays
-void att_split_spectrum( dsp_complex_fp pts[], const uint32_t N ){
+void att_split_spectrum( att_complex_fp pts[], const uint32_t N ){
 
     for(uint32_t i=1;i<N/2;i++){
         double a_re = (pts[i].re + pts[N-i].re)/2;
@@ -170,18 +170,18 @@ void att_split_spectrum( dsp_complex_fp pts[], const uint32_t N ){
 
 
     for(uint32_t i=1;i<N/4;i++){
-        dsp_complex_fp a = pts[N/2 + i];
-        dsp_complex_fp b = pts[N - i];
+        att_complex_fp a = pts[N/2 + i];
+        att_complex_fp b = pts[N - i];
         pts[N/2 + i] = b;
         pts[N - i]  = a;
     }
 }
 
 #pragma unsafe arrays
-void att_merge_spectra( dsp_complex_fp pts[], const uint32_t N ){
+void att_merge_spectra( att_complex_fp pts[], const uint32_t N ){
     for(uint32_t i=1;i<N/4;i++){
-        dsp_complex_fp a = pts[N/2 + i];
-        dsp_complex_fp b = pts[N - i];
+        att_complex_fp a = pts[N/2 + i];
+        att_complex_fp b = pts[N - i];
         pts[N/2 + i] = b;
         pts[N - i]  = a;
     }

--- a/audio_test_tools/src/testing.xc
+++ b/audio_test_tools/src/testing.xc
@@ -1,5 +1,6 @@
 // Copyright (c) 2017-2019, XMOS Ltd, All rights reserved
 #include "audio_test_tools.h"
+#include "voice_toolbox.h"
 
 #include <xs1.h>
 #include <limits.h>
@@ -526,7 +527,7 @@ void att_limit_bits(att_complex_t * a, unsigned length, unsigned bits){
     if(bits >= 32)
         return;
 
-    unsigned hr = dsp_bfp_cls(a, length)-1;
+    unsigned hr = vtb_bfp_cls(a, length)-1;
     int mask = bitrev((1<<bits)-1);
 
     mask >>= hr;

--- a/audio_test_tools/src/testing.xc
+++ b/audio_test_tools/src/testing.xc
@@ -147,29 +147,29 @@ uint64_t att_double_to_uint64(double d, const int d_exp){
     return (uint64_t)ldexp(m, m_exp - d_exp);
 }
 
-dsp_complex_t att_double_to_complex(dsp_complex_fp d, const int d_exp){
-    dsp_complex_t r;
+att_complex_t att_double_to_complex(att_complex_fp d, const int d_exp){
+    att_complex_t r;
     r.re = att_double_to_int32(d.re, d_exp);
     r.im = att_double_to_int32(d.im, d_exp);
     return r;
 }
 
 
-dsp_complex_fp att_complex_int16_to_double(dsp_complex_short_t x, int x_exp){
-    dsp_complex_fp f;
+att_complex_fp att_complex_int16_to_double(att_complex_short_t x, int x_exp){
+    att_complex_fp f;
     f.re = att_int16_to_double(x.re, x_exp);
     f.im = att_int16_to_double(x.im, x_exp);
     return f;
 }
 
-dsp_complex_fp att_complex_int32_to_double(dsp_complex_t x, int x_exp){
-    dsp_complex_fp f;
+att_complex_fp att_complex_int32_to_double(att_complex_t x, int x_exp){
+    att_complex_fp f;
     f.re = att_int32_to_double(x.re, x_exp);
     f.im = att_int32_to_double(x.im, x_exp);
     return f;
 }
 
-unsigned att_bfp_vector_complex_short(dsp_complex_short_t * B, int B_exp, dsp_complex_fp * f, size_t start, size_t count){
+unsigned att_bfp_vector_complex_short(att_complex_short_t * B, int B_exp, att_complex_fp * f, size_t start, size_t count){
     int16_t * b_int = (int16_t *) B;
     double * f_double = (double *) f;
     return att_bfp_vector_int16(b_int, B_exp, f_double, start*2, count*2);
@@ -203,7 +203,7 @@ unsigned att_bfp_vector_int16(int16_t * B, int B_exp, double * f, size_t start, 
     return max_diff;
 }
 
-unsigned att_bfp_vector_complex(dsp_complex_t * B, int B_exp, dsp_complex_fp * f, size_t start, size_t count){
+unsigned att_bfp_vector_complex(att_complex_t * B, int B_exp, att_complex_fp * f, size_t start, size_t count){
     int32_t * b_int = (int32_t *) B;
     double * f_double = (double *) f;
     return att_bfp_vector_int32(b_int, B_exp, f_double, start*2, count*2);
@@ -296,7 +296,7 @@ void att_print_int_python_uint64(uint64_t * d, size_t length){
 }
 
 
-void att_print_int_python_fd(dsp_complex_t * d, size_t length){
+void att_print_int_python_fd(att_complex_t * d, size_t length){
     printf("np.asarray([%d, ", d[0].re);
     for(size_t i=1;i<length;i++){
         printf("%d + %dj, ", d[i].re, d[i].im);
@@ -304,7 +304,7 @@ void att_print_int_python_fd(dsp_complex_t * d, size_t length){
     printf("%d])\n", d[0].im);
 }
 
-void att_print_int_python_td(dsp_complex_t * d, size_t length, int print_imag){
+void att_print_int_python_td(att_complex_t * d, size_t length, int print_imag){
     printf("np.asarray([");
     if(print_imag){
         for(size_t i=0;i<length;i++)
@@ -316,7 +316,7 @@ void att_print_int_python_td(dsp_complex_t * d, size_t length, int print_imag){
     printf("])\n");
 }
 
-void att_print_python_fd_short(dsp_complex_short_t * d, size_t length, int d_exp){
+void att_print_python_fd_short(att_complex_short_t * d, size_t length, int d_exp){
     printf("np.asarray([%.12f, ", att_int16_to_double( d[0].re, d_exp));
     for(size_t i=1;i<length;i++){
         printf("%.12f + %.12fj, ", att_int16_to_double( d[i].re, d_exp),
@@ -324,7 +324,7 @@ void att_print_python_fd_short(dsp_complex_short_t * d, size_t length, int d_exp
     }
     printf("%.12f])\n", att_int16_to_double( d[0].im, d_exp));
 }
-void att_print_python_td_short(dsp_complex_short_t * d, size_t length, int d_exp, int print_imag){
+void att_print_python_td_short(att_complex_short_t * d, size_t length, int d_exp, int print_imag){
     printf("np.asarray([");
     if(print_imag){
         for(size_t i=0;i<length;i++)
@@ -336,7 +336,7 @@ void att_print_python_td_short(dsp_complex_short_t * d, size_t length, int d_exp
     printf("])\n");
 }
 
-void att_print_python_fd(dsp_complex_t * d, size_t length, int d_exp){
+void att_print_python_fd(att_complex_t * d, size_t length, int d_exp){
     printf("np.asarray([%.12f, ", att_int32_to_double( d[0].re, d_exp));
     for(size_t i=1;i<length;i++){
         printf("%.12f + %.12fj, ", att_int32_to_double( d[i].re, d_exp),
@@ -344,7 +344,7 @@ void att_print_python_fd(dsp_complex_t * d, size_t length, int d_exp){
     }
     printf("%.12f])\n", att_int32_to_double( d[0].im, d_exp));
 }
-void att_print_python_td(dsp_complex_t * d, size_t length, int d_exp, int print_imag){
+void att_print_python_td(att_complex_t * d, size_t length, int d_exp, int print_imag){
     printf("np.asarray([");
     if(print_imag){
         for(size_t i=0;i<length;i++)
@@ -356,14 +356,14 @@ void att_print_python_td(dsp_complex_t * d, size_t length, int d_exp, int print_
     printf("])\n");
 }
 
-void att_print_python_fd_fp(dsp_complex_fp * d, size_t length){
+void att_print_python_fd_fp(att_complex_fp * d, size_t length){
     printf("np.asarray([%.12f, ", d[0].re);
     for(size_t i=1;i<length;i++){
         printf("%.12f + %.12fj, ", d[i].re,d[i].im);
     }
     printf("%.12f])\n", d[0].im);
 }
-void att_print_python_td_fp(dsp_complex_fp * d, size_t length, int print_imag){
+void att_print_python_td_fp(att_complex_fp * d, size_t length, int print_imag){
     printf("np.asarray([");
     if(print_imag){
         for(size_t i=0;i<length;i++)
@@ -435,14 +435,14 @@ void att_trace_new_frame(unsigned &frame_no){
     frame_no++;
 }
 
-void att_trace_complex_td(char name[], dsp_complex_t * d, int exponent, unsigned length, int print_imag){
+void att_trace_complex_td(char name[], att_complex_t * d, int exponent, unsigned length, int print_imag){
     printf("current_frame.update({\"%s\": [[", name);
     for(unsigned i=0;i<length;i++)
         printf("%d, ", (d[i], int32_t[2])[print_imag]);
     printf("], %d]})\n", exponent);
 }
 
-void att_trace_complex_fd(char name[], dsp_complex_t * d, int exponent, unsigned length){
+void att_trace_complex_fd(char name[], att_complex_t * d, int exponent, unsigned length){
     printf("current_frame.update({\"%s\": [[%d,", name, d[0].re);
     for(unsigned i=1;i<length;i++){
         printf("%d+%dj, ", d[i].re, d[i].im);
@@ -450,14 +450,14 @@ void att_trace_complex_fd(char name[], dsp_complex_t * d, int exponent, unsigned
     printf("%d], %d]})\n", d[0].im, exponent);
 }
 
-void att_trace_complex_td_short(char name[], dsp_complex_short_t * d, int exponent, unsigned length, int print_imag){
+void att_trace_complex_td_short(char name[], att_complex_short_t * d, int exponent, unsigned length, int print_imag){
     printf("current_frame.update({\"%s\": [[", name);
     for(unsigned i=0;i<length;i++)
         printf("%d, ", (d[i], int16_t[2])[print_imag]);
     printf("], %d]})\n", exponent);
 }
 
-void att_trace_complex_fd_short(char name[], dsp_complex_short_t * d, int exponent, unsigned length){
+void att_trace_complex_fd_short(char name[], att_complex_short_t * d, int exponent, unsigned length){
     printf("current_frame.update({\"%s\": [[%d,", name, d[0].re);
     for(unsigned i=1;i<length;i++){
         printf("%d+%dj, ", d[i].re, d[i].im);
@@ -521,7 +521,7 @@ void att_divide_array(unsigned * array, unsigned array_length, unsigned space_to
 }
 
 
-void att_limit_bits(dsp_complex_t * a, unsigned length, unsigned bits){
+void att_limit_bits(att_complex_t * a, unsigned length, unsigned bits){
 
     if(bits >= 32)
         return;

--- a/audio_test_tools/src/testing.xc
+++ b/audio_test_tools/src/testing.xc
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019, XMOS Ltd, All rights reserved
+// Copyright (c) 2017-2020, XMOS Ltd, All rights reserved
 #include "audio_test_tools.h"
 #include "voice_toolbox.h"
 

--- a/tests/att_unit_tests/src/test_limit_bits.xc
+++ b/tests/att_unit_tests/src/test_limit_bits.xc
@@ -7,8 +7,8 @@ void test_limit_bits(){
 
     unsigned r = 1;
 
-    dsp_complex_t [[aligned(8)]]a[PROC_FRAME_LENGTH];
-    dsp_complex_t [[aligned(8)]]a_copy[PROC_FRAME_LENGTH];
+    att_complex_t [[aligned(8)]]a[PROC_FRAME_LENGTH];
+    att_complex_t [[aligned(8)]]a_copy[PROC_FRAME_LENGTH];
 
     for(unsigned l=0;l<1<<16;l++){
 

--- a/tests/att_unit_tests/src/test_limit_bits.xc
+++ b/tests/att_unit_tests/src/test_limit_bits.xc
@@ -1,5 +1,6 @@
 // Copyright (c) 2018-2019, XMOS Ltd, All rights reserved
 #include "att_unit_tests.h"
+#include "voice_toolbox.h"
 
 #define PROC_FRAME_LENGTH 256
 
@@ -22,7 +23,7 @@ void test_limit_bits(){
         }
         memcpy(a_copy, a, sizeof(a));
 
-        unsigned a_hr = dsp_bfp_cls(a, PROC_FRAME_LENGTH)-1;
+        unsigned a_hr = vtb_bfp_cls(a, PROC_FRAME_LENGTH)-1;
 
         att_limit_bits(a, PROC_FRAME_LENGTH, bit_limit);
 

--- a/tests/att_unit_tests/src/test_limit_bits.xc
+++ b/tests/att_unit_tests/src/test_limit_bits.xc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, XMOS Ltd, All rights reserved
+// Copyright (c) 2018-2020, XMOS Ltd, All rights reserved
 #include "att_unit_tests.h"
 #include "voice_toolbox.h"
 


### PR DESCRIPTION
Changes:
- Added lib_xs3_math as a library upon which this one depends
- Added ATT-specific synonyms for DSP and XS3-math types
- Use Voice Toolbox to count leading sign bits instead of DSP library

The unit test for audio_test_tools passes on both XS2 (using axe) and XS3 (using the xcore-ai explorer board).