### PR TITLE
Use version in CHANGELOG

### DIFF
--- a/audio_test_tools/module_build_info
+++ b/audio_test_tools/module_build_info
@@ -1,4 +1,4 @@
-VERSION = 4.3.0
+VERSION = 4.3.1
 
 DEPENDENT_MODULES = lib_dsp(>=6.0.1) \
                     lib_voice_toolbox(>=8.0.0)


### PR DESCRIPTION
This issue is breaking the CHANGELOG check for sw_xvf3510