### PR TITLE
Re-apply original copyright dates

### DIFF
--- a/audio_test_tools/api/audio_test_tools.h
+++ b/audio_test_tools/api/audio_test_tools.h
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 XMOS LIMITED.
+// Copyright 2017-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #ifndef AUDIO_TEST_TOOLS_H_

--- a/audio_test_tools/src/burners.S
+++ b/audio_test_tools/src/burners.S
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 XMOS LIMITED.
+// Copyright 2017-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 	.text
     .issue_mode  dual

--- a/audio_test_tools/src/floating_fft.xc
+++ b/audio_test_tools/src/floating_fft.xc
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 XMOS LIMITED.
+// Copyright 2017-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <math.h>
 #include <string.h>

--- a/audio_test_tools/src/process_wav.xc
+++ b/audio_test_tools/src/process_wav.xc
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 XMOS LIMITED.
+// Copyright 2017-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #include <fcntl.h>

--- a/audio_test_tools/src/testing.xc
+++ b/audio_test_tools/src/testing.xc
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 XMOS LIMITED.
+// Copyright 2017-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "audio_test_tools.h"
 

--- a/python/test_wav_erle.py
+++ b/python/test_wav_erle.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 XMOS LIMITED.
+# Copyright 2018-2021 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import numpy as np
 import scipy.io.wavfile

--- a/python/thdncalculator.py
+++ b/python/thdncalculator.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 XMOS LIMITED.
+# Copyright 2019-2021 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import sys, os
 from scipy.signal import blackmanharris

--- a/tests/att_unit_tests/conftest.py
+++ b/tests/att_unit_tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 XMOS LIMITED.
+# Copyright 2018-2021 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 from __future__ import print_function
 from builtins import str

--- a/tests/att_unit_tests/src/att_unit_tests.h
+++ b/tests/att_unit_tests/src/att_unit_tests.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 XMOS LIMITED.
+// Copyright 2018-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #ifndef VTB_UNIT_TESTS_H_
 #define VTB_UNIT_TESTS_H_

--- a/tests/att_unit_tests/src/test_limit_bits.xc
+++ b/tests/att_unit_tests/src/test_limit_bits.xc
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 XMOS LIMITED.
+// Copyright 2018-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "att_unit_tests.h"
 

--- a/tests/test_parse_wav_header/src/test_wav.xc
+++ b/tests/test_parse_wav_header/src/test_wav.xc
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 XMOS LIMITED.
+// Copyright 2017-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #include <fcntl.h>


### PR DESCRIPTION
With the fix in infr_apps, the source check script can now maintain the original copyright dates on files.