### PR TITLE
Use xcore.ai jenkins label

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,7 +118,7 @@ pipeline {
     }//Standard build and XS2 tests
     stage('xcore.ai Verification'){
       agent {
-        label 'xcore.ai-explorer'
+        label 'xcore.ai'
       }
       options {
         skipDefaultCheckout()


### PR DESCRIPTION
Use any compatible board rather than specifying the explorer.
We've changed some agents over to use evk and voice reference design boards.
This repo should be able to use any of them.