### PR TITLE
Replace uses of Python sh module with subprocess

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Audio test tools change log
 ===========================
 
+4.5.2
+-----
+
+  * REMOVED: Python sh module dependency
+
 4.5.1
 -----
 

--- a/audio_test_tools/module_build_info
+++ b/audio_test_tools/module_build_info
@@ -1,4 +1,4 @@
-VERSION = 4.5.1
+VERSION = 4.5.2
 
 DEPENDENT_MODULES = lib_dsp(>=6.0.0) \
                     lib_voice_toolbox(>=8.0.0) \

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 XMOS LIMITED.
+# Copyright 2019-2022 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import setuptools
 
@@ -21,7 +21,6 @@ setuptools.setup(
         'pytest~=6.0',
         'pytest-xdist~=1.34',
         'scipy~=1.4',
-        'sh~=1.13',
     ],
     dependency_links=[
     ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,8 +29,6 @@ pytest-xdist==1.34.0
 # Pin scipy to 1.4.1 due to tensorflow v2.1.1 hard pinning it to that version.
 scipy==1.4.1
 
-sh==1.13.1
-
 # Development dependencies
 #
 # Each link listed below specifies the path to a setup.py file which are

--- a/tests/test_xscope_process_wav/test_xscope_wav.py
+++ b/tests/test_xscope_process_wav/test_xscope_wav.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 XMOS LIMITED.
+# Copyright 2018-2022 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 import numpy as np
@@ -10,7 +10,7 @@ import os
 import xscope_fileio
 import xtagctl
 from io import StringIO
-import sh
+import subprocess
 
 TEST_LEN_SECONDS=15
 INFILE="input.wav"
@@ -30,8 +30,10 @@ def test_test_wav_xscope():
     for ch in range(4):
         filename = f"noise_ch{ch}.wav"
         filenames.append(filename)
-        sh.sox(f"-n -c 1 -b 32 -r 16000 -e signed-integer {filename} synth {length_rounded_to_frame} whitenoise vol 1.0".split())
-    sh.sox(f"-M {' '.join(filenames)} {input_file} remix 1 2 3 4".split())
+        cmd_opts = f"-n -c 1 -b 32 -r 16000 -e signed-integer {filename} synth {length_rounded_to_frame} whitenoise vol 1.0"
+        subprocess.run(["sox", *cmd_opts.split()])
+    cmd_opts = f"-M {' '.join(filenames)} {input_file} remix 1 2 3 4"
+    subprocess.run(["sox", *cmd_opts.split()])
     for filename in filenames:
         os.remove(filename)
 
@@ -55,11 +57,11 @@ def test_test_wav_xscope():
 if __name__ == "__main__":
     #If running locally, make sure we build fw. This would normally be done by jenkins
     print("Building firmware")
-    sh.waf("configure build".split())
+    subprocess.run(["waf", "configure", "build"])
     #Build host app
     print("Building host app")
     os.chdir(os.path.join(package_dir,"../../../xscope_fileio/host"))
-    sh.make()
+    subprocess.run(["make"])
     os.chdir(package_dir)
 
     test_test_wav_xscope()


### PR DESCRIPTION
Removed the Python sh module dependency and replaced uses of sh with subprocess.

I've run all of the relevant develop branch Jenkins jobs with a custom view to include this change:
- [lib_aec](http://srv-bri-jcim0:8080/blue/organizations/jenkins/XMOS%2Flib_aec/detail/develop/1099)
- [lib_agc](http://srv-bri-jcim0:8080/blue/organizations/jenkins/XMOS%2Flib_agc/detail/develop/877)
- [lib_audio_pipelines](http://srv-bri-jcim0:8080/blue/organizations/jenkins/XMOS%2Flib_audio_pipelines/detail/develop/980)
- [lib_interference_canceller](http://srv-bri-jcim0:8080/blue/organizations/jenkins/XMOS%2Flib_interference_canceller/detail/develop/1077)
- [lib_noise_suppression](http://srv-bri-jcim0:8080/blue/organizations/jenkins/XMOS%2Flib_noise_suppression/detail/develop/1031)
- [lib_voice_toolbox](http://srv-bri-jcim0:8080/blue/organizations/jenkins/XMOS%2Flib_voice_toolbox/detail/develop/1031)
- [py_vnr](http://srv-bri-jcim0:8080/blue/organizations/jenkins/XMOS%2Fpy_vnr/detail/develop/94)
- [sw_xvf3510](http://srv-bri-jcim0:8080/blue/organizations/jenkins/XMOS%2Fsw_xvf3510/detail/develop/1106)
- [sw_xvf3610](http://srv-bri-jcim0:8080/blue/organizations/jenkins/XMOS%2Fsw_xvf3610/detail/develop/578)

There is a bug in xscope_fileio v0.3.2 and earlier that the sh dependency wasn't explicitly installed by that library and it relied on another library to install it. Since audio_test_tools will no longer install sh for xscope_fileio, the develop views for the following repos need to update xscope_fileio to v1.1.1 when this change is merged in audio_test_tools:
- lib_agc
- lib_interference_canceller
- sw_xvf3510
- sw_xvf3610