### PR TITLE
use warnError on library checks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,14 +30,18 @@ pipeline {
             stage ("Flake 8") {
               steps {
                 viewEnv() {
-                  flake("${REPO}")
+                  warnError("Flake") {
+                    flake("${REPO}")
+                  }
                 }
               }
             }
             stage ("Copyright") {
               steps {
                 viewEnv() {
-                  sourceCheck("${REPO}")
+                  warnError("Source") {
+                    sourceCheck("${REPO}")
+                  }
                 }
               }
             }
@@ -51,7 +55,9 @@ pipeline {
             stage ("Clang style") {
               steps {
                 viewEnv() {
-                  clangStyleCheck()
+                  warnError("Clang Style") {
+                    clangStyleCheck()
+                  }
                 }
               }
             }

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,9 @@ pytest-xdist==1.34.0
 # Pin scipy to 1.4.1 due to tensorflow v2.1.1 hard pinning it to that version.
 scipy==1.4.1
 
+# Pin importlib-metadata to <5 due to https://github.com/python/importlib_metadata/issues/409.
+importlib-metadata==4.13.0
+
 # Development dependencies
 #
 # Each link listed below specifies the path to a setup.py file which are


### PR DESCRIPTION
This matches behaviour in `xcoreLibraryChecks`.
Currently, an issue with an update to a flake8 dependency is causing jobs like this to be red and untested.
This will cause them to go yellow and continue testing further than flake8.