### PR TITLE
Specify files for setuptools export

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -20,3 +20,15 @@ test = [
     "flake8",
     "pylint",
 ]
+
+[tool.setuptools]
+py-modules = [
+    "audio_generation",
+    "audio_utils",
+    "audio_wav_utils",
+    "common_utils",
+    "pcm_to_pdm",
+    "test_wav_erle",
+    "thdncalculator",
+    "wav_comp"
+]


### PR DESCRIPTION
Add explicit instructions for setuptools to define which files to export as Python modules.

Basically because this repo is laid out in a way that python does not particularly like (ie a big flat list of files in a python directory) and we want to import all of them as `import thdncalculator` instead of `from audio_test_tools import thdncalculator`, we need to tell setuptools which things we want available at the module level.